### PR TITLE
Fix the querySelector selection of source repository

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -35,7 +35,7 @@
     const network = document.querySelector("#network");
 
     // like: musically-ut/lovely-forks
-    const sourceRepoName = network.querySelector("span.current-repository").lastElementChild.getAttribute("href").substring(1);
+    const sourceRepoName = network.firstElementChild.lastElementChild.getAttribute("href").substring(1);
     console.log("TCL: currentRepoUrl", sourceRepoName);
     const sourceAuthorName = sourceRepoName.substring(0, sourceRepoName.lastIndexOf("/"));
     // like: https://api.github.com/repos/GhettoSanta/lovely-forks/forks?sort=stargazers


### PR DESCRIPTION
Apparently github has at some point changed the DOM so that there is no span with a class of "current-repository". Instead, just assume that the source repository is always the first element in the list of forks, and get it with firstElementChild.